### PR TITLE
Add shortkeys for menubar operations

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,11 +4,12 @@
   "private": true,
   "homepage": "https://github.com/tarantool/graphqlide",
   "dependencies": {
+    "@emotion/css": "11.5.0",
     "@tarantool.io/frontend-core": "7.12.1",
     "@tarantool.io/ui-kit": "0.50.2",
-    "@emotion/css": "11.5.0",
     "graphiql": "1.5.4",
-    "graphql": "16.0.1"
+    "graphql": "16.0.1",
+    "react-hot-keys": "^2.7.1"
   },
   "devDependencies": {
     "@babel/core": "7.16.0",
@@ -26,10 +27,10 @@
     "dotenv-expand": "5.1.0",
     "eslint": "8.3.0",
     "eslint-config-prettier": "8.3.0",
-    "eslint-webpack-plugin": "3.1.1",
     "eslint-plugin-flowtype": "8.0.3",
     "eslint-plugin-prettier": "4.0.0",
     "eslint-plugin-react": "7.27.1",
+    "eslint-webpack-plugin": "3.1.1",
     "file-loader": "6.2.0",
     "file-saver": "2.0.5",
     "fs-extra": "10.0.0",
@@ -109,7 +110,12 @@
   "babel": {
     "presets": [
       "@babel/preset-flow",
-      ["react-app", { "absoluteRuntime": false }]
+      [
+        "react-app",
+        {
+          "absoluteRuntime": false
+        }
+      ]
     ],
     "plugins": [
       "@emotion"


### PR DESCRIPTION
Add shortkeys for all menu operations:
Ctrl+Enter - Run query
Alt+Shift+E - Toggle Explorer
Alt+Shift+H - Toggle History
Alt+Shift+P - Prettify query
Alt+Shift+M - Merge query
Alt+Shift+C - Copy query to clipboard
Alt+Shift+Q - Save query
Alt+Shift+R - Save response
Alt+Shift+D - Toggle DocExplorer

closes https://github.com/tarantool/graphqlide/issues/15