### PR TITLE
Allow defaults for mandatory arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- `update graphiql@1.5.16 to graphiql@1.5.17`
+- `allow defaults for mandatory arguments`
+
 ## 0.0.18
 
 - `coerce arguments default values`

--- a/src/graphiql-explorer/GraphiQLExplorer.tsx
+++ b/src/graphiql-explorer/GraphiQLExplorer.tsx
@@ -272,7 +272,7 @@ function isListArgument(arg : GraphQLArgument) : boolean {
 }
 
 function isRequiredArgument(arg : GraphQLArgument) : boolean {
-  return isNonNullType(arg.type) && arg.defaultValue === undefined;
+  return isNonNullType(arg.type);
 }
 
 function unwrapOutputType(outputType : GraphQLOutputType) : any {


### PR DESCRIPTION
Before this patch where is impossible to point defaultValue for mandatory arguments. This PR fixes that behavior.