### PR TITLE
Fix show variablize button if request is printed manually or selected from history

### DIFF
--- a/src/graphiql-explorer/GraphiQLExplorer.tsx
+++ b/src/graphiql-explorer/GraphiQLExplorer.tsx
@@ -1131,7 +1131,7 @@ class AbstractArgView extends React.PureComponent<
   AbstractArgViewProps,
   {displayArgActions : boolean},
 > {
-  state = {displayArgActions: false};
+  state = {displayArgActions: !!this.props.argValue};
   render() {
     const {
       argValue,


### PR DESCRIPTION
Before this PR variablize button is not available if request was printed manually or selected from history. To make it visiable user have to toggle argument selection. This PR fixes the behaivor in such cases.