### PR TITLE
fix tree open/close arrow when arguments only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - `update graphiql@1.5.17 to graphiql@1.7.0`
 - `update @tarantool.io/lua-bundler-webpack-plugin@1.0.0 to @tarantool.io/lua-bundler-webpack-plugin@2.0.0`
 - `update multiple dependencies to latest`
+- `fix tree open/close arrow is not shown if operation has only arguments`
 
 ## 0.0.19
 

--- a/src/graphiql-explorer/GraphiQLExplorer.tsx
+++ b/src/graphiql-explorer/GraphiQLExplorer.tsx
@@ -2126,7 +2126,7 @@ class FieldView extends React.PureComponent<FieldViewProps, {displayFieldActions
             data-field-type={type.name}
             onClick={this._handleUpdateSelections}
           >
-            {isObjectType(type) ? (
+            {(isObjectType(type) || args.length) ? (
               <span>
                 {selection
                   ? this.props.styleConfig.arrowOpen


### PR DESCRIPTION
fix tree open/close arrow is not shown if operation has only arguments