### PR TITLE
Release 0.0.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.0.20
 
 - `update graphiql@1.5.17 to graphiql@1.8.3`
 - `update @tarantool.io/lua-bundler-webpack-plugin@1.0.0 to @tarantool.io/lua-bundler-webpack-plugin@2.0.1`


### PR DESCRIPTION
- `update graphiql@1.5.17 to graphiql@1.8.3`
- `update @tarantool.io/lua-bundler-webpack-plugin@1.0.0 to @tarantool.io/lua-bundler-webpack-plugin@2.0.1`
- `update multiple dependencies to latest`
- `fix tree open/close arrow is not shown if operation has only arguments`
- `update node.js@17.6.0 to node.js@17.8.0`
- `update prettier@2.5.0 to prettier@2.6.2`
- `update @tarantool.io/frontend-core@8.0.0 to  @tarantool.io/frontend-core@8.1.1`